### PR TITLE
Add async before running element query in three-up card

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-widget-cards",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "main": [
     "px-widget-cards.html"
   ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "px-widget-cards",
     "author": "General Electric",
     "description": "A Px component",
-    "version": "1.4.3",
+    "version": "1.4.4",
     "private": true,
     "extName" : null,
     "repository" :

--- a/px-threeup.html
+++ b/px-threeup.html
@@ -25,8 +25,11 @@
   Polymer({
     is: 'px-threeup',
     attached: function() {
-      eqjs.refreshNodes();
-      eqjs.query(undefined, true);
+      //delay the element query from executing until px-card dimension is determined.
+      this.async(function(){
+        eqjs.refreshNodes();
+        eqjs.query(undefined, true);
+      },1);
     }
   });
 </script>


### PR DESCRIPTION
Hi,

Add a delay to three-up card attach method before running the element query. if the element query runs before the px-card is displayed, the element query will not be able to determine the size of the card and the widget dividing line will display horizontally instead of vertically. 
